### PR TITLE
Added IP check for security

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -16,8 +16,13 @@ if ($_GET['test'] == true) {
   return;
 }
 
+if (gethostbyname('blackchain.info') != $_SERVER['REMOTE_ADDR']) {
+  echo 'Incorrect IP Address';
+  return;
+}
+
 if ($_GET['address'] != $my_bitcoin_address) {
-    echo 'Incorrect Receiving Address';
+  echo 'Incorrect Receiving Address';
   return;
 }
 


### PR DESCRIPTION
The API documentation says that scripts should include a check to ensure the GET request was made by the IP that blockchain.info points to. I have added in this check to prevent people faking callbacks. 
Appending another GET variable to your query string as a secret would also be advisable to further ensure validity. For example you could make your callback URL http://exampl.com/callback.php?secret=abc123 and then check that $_GET['secret'] is correctly set in your script.